### PR TITLE
Added shutter control

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ const stillCamera = new StillCamera({
 - [`rotation: Rotation`](#rotation) - *Default: `Rotation.Rotate0`*
 - [`flip: Flip`](#flip) - *Default: `Flip.None`*
 - `delay: number` - *Default: 1 ms*
-- [`shutter: number`](#flip) - *Default: `Not set. Number is in micro seconds, i.e. 6000 is a shutter speed of 6000 micro seconds`
+- `shutter: number` - *Default: Auto calculated based on framerate (1000000µs/fps). Number is in microseconds*
 
 ### `StillCamera.takeImage(): Promise<Buffer>`
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ const stillCamera = new StillCamera({
 - [`rotation: Rotation`](#rotation) - *Default: `Rotation.Rotate0`*
 - [`flip: Flip`](#flip) - *Default: `Flip.None`*
 - `delay: number` - *Default: 1 ms*
+- [`shutter: number`](#flip) - *Default: `Not set. Number is in micro seconds, i.e. 6000 is a shutter speed of 6000 micro seconds`
 
 ### `StillCamera.takeImage(): Promise<Buffer>`
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository" :
   {
     "type" : "git",
-    "url" : "https://github.com/amcelroy/pi-camera-connect"
+    "url" : "https://github.com/amcelroy/pi-camera-connect#shutter"
   },
   "scripts": {
     "test": "jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository" :
   {
     "type" : "git",
-    "url" : "https://github.com/amcelroy/pi-camera-connect#shutter"
+    "url" : "https://github.com/servall/pi-camera-connect"
   },
   "scripts": {
     "test": "jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository" :
   {
     "type" : "git",
-    "url" : "https://github.com/servall/pi-camera-connect"
+    "url" : "https://github.com/amcelroy/pi-camera-connect"
   },
   "scripts": {
     "test": "jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository" :
   {
     "type" : "git",
-    "url" : "https://github.com/amcelroy/pi-camera-connect"
+    "url" : "https://github.com/servall/pi-camera-connect"
   },
   "scripts": {
     "test": "jest --runInBand",

--- a/src/lib/still-camera.ts
+++ b/src/lib/still-camera.ts
@@ -7,6 +7,7 @@ export interface StillOptions {
 	rotation?: Rotation;
 	flip?: Flip;
 	delay?: number;
+	shutter?: number;
 }
 
 export default class StillCamera {

--- a/src/lib/still-camera.ts
+++ b/src/lib/still-camera.ts
@@ -45,7 +45,12 @@ export default class StillCamera {
 				 * Rotation
 				 */
 				...(this.options.rotation ? ["--rotation", this.options.rotation.toString()] : []),
-
+				
+				/**
+				* Shutter Speed
+				*/
+				...(this.options.shutter ? ["--shutter", this.options.shutter.toString()] : []),
+				
 				/**
 				 * Horizontal flip
 				 */


### PR DESCRIPTION
Added a shutter control option, option is set in Microseconds. From raspistill docs:

Sets the shutter speed to the specified value (in microseconds). There's currently an upper limit of approximately 6000000us (6000ms, 6s), past which operation is undefined.