### PR TITLE
Using pi-camera-connect with a CM3+

### DIFF
--- a/src/lib/still-camera.ts
+++ b/src/lib/still-camera.ts
@@ -38,6 +38,7 @@ export default class StillCamera {
     const systemInfo = await si.system();
     switch (systemInfo.model) {
       case 'BCM2711':
+	  case 'BCM2835':
       case 'BCM2835 - Pi 3 Model B':
       case 'BCM2835 - Pi 3 Model B+':
       case 'BCM2835 - Pi 4 Model B':

--- a/src/lib/stream-camera.ts
+++ b/src/lib/stream-camera.ts
@@ -71,6 +71,7 @@ class StreamCamera extends EventEmitter {
     const systemInfo = await si.system();
     switch (systemInfo.model) {
       case 'BCM2711':
+	  case 'BCM2835':
       case 'BCM2835 - Pi 3 Model B':
       case 'BCM2835 - Pi 3 Model B+':
       case 'BCM2835 - Pi 4 Model B':


### PR DESCRIPTION
Solves error "(node:2021) UnhandledPromiseRejectionWarning: Error: Could not determine JPEG signature. Unknown system model 'BCM2835'"

P.S. The error only arises when using the StreamCamera, not the StillCamera

EDIT: Added system information
```
pi@raspberrypi:~/clog/clog_server $ uname -a
Linux raspberrypi 5.4.70-v7+ #3 SMP Fri Oct 16 19:24:58 CEST 2020 armv7l GNU/Linux
pi@raspberrypi:~/clog/clog_server $ cat /etc/os-release 
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
pi@raspberrypi:~/clog/clog_server $ vcgencmd version
Aug 19 2020 17:41:31 
Copyright (c) 2012 Broadcom
version e90cba19a98a0d1f2ef086b9cafcbca00778f094 (clean) (release) (start_x)
```